### PR TITLE
Add a note about YouTube to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,8 @@ body:
       options:
         - label: I verified that this is not a filter list issue. Report any issues with filter lists or broken website functionality in the [uAssets issue tracker](https://github.com/uBlockOrigin/uAssets/issues).
           required: true
+        - label: This is NOT an issue with [YouTube](https://www.github.com/uBlockOrigin/uAssets/issues/19976), [Facebook](https://www.github.com/uBlockOrigin/uAssets/issues/3367) or [Twitch](https://www.github.com/uBlockOrigin/uAssets/issues/5184).
+          required: true
         - label: This is not a support issue or a question. For support, questions, or help, visit [/r/uBlockOrigin](https://www.reddit.com/r/uBlockOrigin/).
           required: true
         - label: I performed a [cursory search of the issue tracker](https://github.com/uBlockOrigin/uBlock-issues/issues?q=is%3Aissue) to avoid opening a duplicate issue.

--- a/.github/ISSUE_TEMPLATE/bug_report_from_ubo.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_from_ubo.yml
@@ -18,6 +18,8 @@ body:
       options:
         - label: I verified that this is not a filter list issue. Report any issues with filter lists or broken website functionality in the [uAssets issue tracker](https://github.com/uBlockOrigin/uAssets/issues).
           required: true
+        - label: This is NOT an issue with [YouTube](https://www.github.com/uBlockOrigin/uAssets/issues/19976), [Facebook](https://www.github.com/uBlockOrigin/uAssets/issues/3367) or [Twitch](https://www.github.com/uBlockOrigin/uAssets/issues/5184).
+          required: true
         - label: I performed a [cursory search of the issue tracker](https://github.com/uBlockOrigin/uBlock-issues/issues?q=is%3Aissue) to avoid opening a duplicate issue.
           required: true
         - label: The issue is not present after disabling uBO in the browser.


### PR DESCRIPTION
[There seem to be countless (49) issues relating to YouTube which are incorrectly submitted here instead of the YouTube thread](https://github.com/uBlockOrigin/uBlock-issues/issues?q=youtube+label%3Afilterlist), so I have roughly copied the warning which has been added to the uAssets issue template.
While it's just another checkbox most will ignore, but maybe someone who doesn't understand what a filterlist is will see it and report their issue in the correct place.
Thanks